### PR TITLE
Keep search_name partitions when executing --drop

### DIFF
--- a/utils/setup.php
+++ b/utils/setup.php
@@ -658,7 +658,7 @@ if ($aCMDResult['drop']) {
                     'location_postcode',
                     'location_property*',
                     'placex',
-                    'search_name',
+                    'search_name*',
                     'seq_*',
                     'word',
                     'query_log',


### PR DESCRIPTION
Adapted the table whitelist to keep the following tables:

```
search_name_[0-9]+
search_name_blank
search_name_country
```